### PR TITLE
bugfix: avoid overriding ipv4 rule with the same mask.

### DIFF
--- a/resty/ipmatcher.lua
+++ b/resty/ipmatcher.lua
@@ -211,7 +211,7 @@ local function new(ips, with_value)
             else
                 local valid_inet_addr = bit.rshift(inet_ipv4, 32 - ip_addr_mask)
 
-                parsed_ipv4s_mask[ip_addr_mask] = parsed_ipv4s[ip_addr_mask] or {}
+                parsed_ipv4s_mask[ip_addr_mask] = parsed_ipv4s_mask[ip_addr_mask] or {}
                 parsed_ipv4s_mask[ip_addr_mask][valid_inet_addr] = value
                 log_info("ipv4 mask: ", ip_addr_mask,
                          " valid inet: ", valid_inet_addr)

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -385,3 +385,26 @@ GET /t
 2
 1
 1
+
+
+
+=== TEST 12: bug: ipv4 address overrided with the same mask
+--- config
+    location /t {
+        content_by_lua_block {
+            local ip = require("resty.ipmatcher").new({
+                "192.168.0.0/16",
+                "192.0.0.0/16",
+            })
+
+            ngx.say(ip:match("192.168.1.1"))
+            ngx.say(ip:match("192.0.1.100"))
+        }
+    }
+--- request
+GET /t
+--- no_error_log
+[error]
+--- response_body
+true
+true


### PR DESCRIPTION
This bug is introduced in commit eab27a27d98f4794279b34f389141f68d26fdf9e,
which affects v0.5.