### PR TITLE
fix make install by deleting unused command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ test:
 install:
 	$(INSTALL) -d $(INST_LUADIR)/resty/
 	$(INSTALL) resty/*.lua $(INST_LUADIR)/resty/
-	$(INSTALL) $(C_SO_NAME) $(INST_LIBDIR)/
 
 
 ### help:         Show Makefile rules


### PR DESCRIPTION
`$(INSTALL) $(C_SO_NAME) $(INST_LIBDIR)/` seems to be a leftover from https://github.com/api7/lua-resty-ipmatcher/commit/8be13b5772a5aab133d98b9d0b72eb74468d5803#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52 and currently causes `make install` to fail.